### PR TITLE
configure deploy environments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,6 +47,7 @@ Session.vim
 # env
 env.yml
 .env
+.env.production
 
 # Jetbrains IDEs
 .idea

--- a/package.json
+++ b/package.json
@@ -4,7 +4,9 @@
   "description": "A Node.js starter for the Serverless Framework with async/await and unit test support",
   "main": "handler.js",
   "scripts": {
-    "test": "serverless-bundle test"
+    "test": "serverless-bundle test",
+    "deploy:dev": "sls deploy",
+    "deploy:prod": "sls deploy --stage prod --env production"
   },
   "author": "",
   "license": "MIT",

--- a/resources/cognito.yml
+++ b/resources/cognito.yml
@@ -38,7 +38,7 @@ Resources:
 
     LambdaCognitoUserPoolExecutionPermission:
       Type: AWS::Lambda::Permission
-      Properties: 
+      Properties:
         Action: lambda:InvokeFunction
         FunctionName: "arn:aws:lambda:#{AWS::Region}:#{AWS::AccountId}:function:backend-api-${self:custom.stage}-preSignupLambdaFunction"
         Principal: cognito-idp.amazonaws.com
@@ -46,24 +46,24 @@ Resources:
 
     LambdaCreateCompanyExecutionPermission:
       Type: AWS::Lambda::Permission
-      Properties: 
+      Properties:
         Action: lambda:InvokeFunction
         FunctionName: "arn:aws:lambda:#{AWS::Region}:#{AWS::AccountId}:function:backend-api-${self:custom.stage}-companyCreate"
         Principal: cognito-idp.amazonaws.com
         SourceArn: !Sub 'arn:#{AWS::Partition}:cognito-idp:#{AWS::Region}:#{AWS::AccountId}:userpool/#{CognitoUserPool}'
 
     # Cognito - Authorizer
-    apiGatewayAuthorizer: 
+    apiGatewayAuthorizer:
       Type: AWS::ApiGateway::Authorizer
-      Properties: 
+      Properties:
         Name: cognitoAuthorizer
         Type: COGNITO_USER_POOLS
         IdentitySource: method.request.header.Authorization
         RestApiId:
           Ref: 'ApiGatewayRestApi'
-        ProviderARNs: 
+        ProviderARNs:
           - 'arn:aws:cognito-idp:#{AWS::Region}:#{AWS::AccountId}:userpool/#{CognitoUserPool}'
-    
+
     # Cognito - Client
     CognitoUserPoolClient:
       Type: AWS::Cognito::UserPoolClient
@@ -96,7 +96,6 @@ Resources:
     CognitoAuthRole:
       Type: AWS::IAM::Role
       Properties:
-        RoleName: appAuthRole
         Path: /
         AssumeRolePolicyDocument:
           Version: "2012-10-17"
@@ -131,7 +130,6 @@ Resources:
     CognitoUnauthRole:
       Type: AWS::IAM::Role
       Properties:
-        RoleName: appUnauthRole
         Path: /
         AssumeRolePolicyDocument:
           Version: "2012-10-17"
@@ -157,4 +155,3 @@ Resources:
                     - "cognito-sync:*"
                     - "cognito-identity:*"
                   Resource: "*"
-                  

--- a/serverless.yml
+++ b/serverless.yml
@@ -26,9 +26,9 @@ provider:
     GEOCODE_API_KEY: ${env:GEOCODE_API_KEY}
     GEOCODE_ENDPOINT: ${env:GEOCODE_ENDPOINT}
     GEOCODE_REGION: ${env:GEOCODE_REGION}
-    COMPANIES_TABLE_NAME: ${env:COMPANIES_TABLE_NAME}
-    USERS_TABLE_NAME: ${env:USERS_TABLE_NAME}
-    COUPONS_TABLE_NAME: ${env:COUPONS_TABLE_NAME}
+    COMPANIES_TABLE_NAME: ${self:custom.stage}-companies
+    USERS_TABLE_NAME: ${self:custom.stage}-users
+    COUPONS_TABLE_NAME: ${self:custom.stage}-coupons
     STRIPE_API_SECRET_KEY: ${env:STRIPE_API_SECRET_KEY}
     STRIPE_API_CLIENT_ID: ${env:STRIPE_API_CLIENT_ID}
     STRIPE_CONNECT_URL: ${env:STRIPE_CONNECT_URL}
@@ -55,7 +55,7 @@ provider:
 
 custom:
   stage: ${opt:stage, self:provider.stage}
-  
+
 functions:
   # Defines an HTTP API endpoint that calls the main function in address/get.js
   # - path: url path is /address/{postalCode}/{houseNumber}
@@ -120,7 +120,7 @@ functions:
               Ref: apiGatewayAuthorizer
 
   preSignupLambdaFunction:
-   handler: cognito/autoConfirmUser.main
+    handler: cognito/autoConfirmUser.main
 
   stripeConnectCallback:
     handler: stripe/connectCallback.main


### PR DESCRIPTION
I have changed two things here
- I removed the table names from the .env. It was overriding some of my settings when in combination with the stage where this API gets deployed
- I removed `RoleName` from the `cognito.yml`. It wasn't really needed, and it was conflicting with different stages